### PR TITLE
PBD-2328: wait before returning a 504 timeout

### DIFF
--- a/app/uk/gov/hmrc/platformstatusfrontend/controllers/CodeController.scala
+++ b/app/uk/gov/hmrc/platformstatusfrontend/controllers/CodeController.scala
@@ -53,11 +53,13 @@ class CodeController @Inject()(appConfig: AppConfig, mcc: MessagesControllerComp
         BadRequest( views.html.code(formWithErrors) )
       },
       codeRequest => {
+        if (codeRequest.code == 504) {
+          Thread.sleep(10000L)
+        }
         new Status(codeRequest.code)(views.html.codeResponse(codeRequest.code, codeRequest.message))
       }
     )
   }
 
 }
-
 

--- a/app/uk/gov/hmrc/platformstatusfrontend/guice/SlowStartModule.scala
+++ b/app/uk/gov/hmrc/platformstatusfrontend/guice/SlowStartModule.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/test/uk/gov/hmrc/platformstatusfrontend/guice/SlowStartModuleSpec.scala
+++ b/test/uk/gov/hmrc/platformstatusfrontend/guice/SlowStartModuleSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 HM Revenue & Customs
+ * Copyright 2020 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Add a sleep in the code generation endpoint so, when we generate a 504
(Gateway timeout) it actually waits a bit instead of returning
straightaway, simulating an actual (testable) timeout

Co-Authored-by: Ali Bahman <1422984+webit4me@users.noreply.github.com>