### PR TITLE
BDOG-2684: proxy timeout in config

### DIFF
--- a/app/uk/gov/hmrc/platformstatusfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/platformstatusfrontend/config/AppConfig.scala
@@ -17,29 +17,28 @@
 package uk.gov.hmrc.platformstatusfrontend.config
 
 import play.api.Configuration
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.{Duration, FiniteDuration}
 
 @Singleton
-class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig) {
+class AppConfig @Inject()(config: Configuration) {
 
   val analyticsToken: String      = config.get[String](s"google-analytics.token")
   val analyticsHost : String      = config.get[String](s"google-analytics.host")
   val startupDelay  : Option[Int] = config.getOptional[Int]("startup-delay")
 
-  lazy val dbUrl                  = servicesConfig.getString("mongodb.uri")
+  lazy val dbUrl                  = config.get[String]("mongodb.uri")
 
-  lazy val proxyProtocol: String   = servicesConfig.getString("proxy.protocol")
-  lazy val proxyHost    : String   = servicesConfig.getString("proxy.host")
-  lazy val proxyPort    : Integer  = servicesConfig.getInt("proxy.port")
-  lazy val proxyTimeout : Duration = servicesConfig.getDuration("proxy.timeout")
-  lazy val proxyUsername: String   = servicesConfig.getString("proxy.username")
-  lazy val proxyPassword: String   = servicesConfig.getString("proxy.password")
-  lazy val proxyRequired: Boolean  = servicesConfig.getBoolean("proxy.required")
+  lazy val proxyProtocol: String   = config.get[String]("proxy.protocol")
+  lazy val proxyHost    : String   = config.get[String]("proxy.host")
+  lazy val proxyPort    : Integer  = config.get[Int]("proxy.port")
+  lazy val proxyTimeout : FiniteDuration = config.get[FiniteDuration]("proxy.timeout")
+  lazy val proxyUsername: String   = config.get[String]("proxy.username")
+  lazy val proxyPassword: String   = config.get[String]("proxy.password")
+  lazy val proxyRequired: Boolean  = config.get[Boolean]("proxy.required")
 
-  lazy val badGatewayTimeout: Duration = servicesConfig.getDuration("bad-gateway.timeout")
+  lazy val badGatewayTimeout: Duration = config.get[Duration]("bad-gateway.timeout")
 
   lazy val experimentValue: String = config.get[String]("experiment.value")
 }

--- a/app/uk/gov/hmrc/platformstatusfrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/platformstatusfrontend/config/AppConfig.scala
@@ -16,9 +16,10 @@
 
 package uk.gov.hmrc.platformstatusfrontend.config
 
-import javax.inject.{Inject, Singleton}
 import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
+
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.duration.Duration
 
 @Singleton
@@ -30,12 +31,13 @@ class AppConfig @Inject()(config: Configuration, servicesConfig: ServicesConfig)
 
   lazy val dbUrl                  = servicesConfig.getString("mongodb.uri")
 
-  lazy val proxyProtocol: String  = servicesConfig.getString("proxy.protocol")
-  lazy val proxyHost    : String  = servicesConfig.getString("proxy.host")
-  lazy val proxyPort    : Integer = servicesConfig.getInt("proxy.port")
-  lazy val proxyUsername: String  = servicesConfig.getString("proxy.username")
-  lazy val proxyPassword: String  = servicesConfig.getString("proxy.password")
-  lazy val proxyRequired: Boolean = servicesConfig.getBoolean("proxy.required")
+  lazy val proxyProtocol: String   = servicesConfig.getString("proxy.protocol")
+  lazy val proxyHost    : String   = servicesConfig.getString("proxy.host")
+  lazy val proxyPort    : Integer  = servicesConfig.getInt("proxy.port")
+  lazy val proxyTimeout : Duration = servicesConfig.getDuration("proxy.timeout")
+  lazy val proxyUsername: String   = servicesConfig.getString("proxy.username")
+  lazy val proxyPassword: String   = servicesConfig.getString("proxy.password")
+  lazy val proxyRequired: Boolean  = servicesConfig.getBoolean("proxy.required")
 
   lazy val badGatewayTimeout: Duration = servicesConfig.getDuration("bad-gateway.timeout")
 

--- a/app/uk/gov/hmrc/platformstatusfrontend/services/StatusChecker.scala
+++ b/app/uk/gov/hmrc/platformstatusfrontend/services/StatusChecker.scala
@@ -88,7 +88,7 @@ class StatusChecker @Inject()(
     for {
       wsResult <- internetConnector
                     .callTheWeb(webTestEndpoint, appConfig.proxyRequired)
-                    .withTimeout(FiniteDuration(appConfig.proxyTimeout.toSeconds, SECONDS))
+                    .withTimeout(appConfig.proxyTimeout)
                     .recoverWith {
                       case ex: Exception =>
                         logger.warn("Unable to call out via squid proxy")

--- a/app/uk/gov/hmrc/platformstatusfrontend/services/StatusChecker.scala
+++ b/app/uk/gov/hmrc/platformstatusfrontend/services/StatusChecker.scala
@@ -17,21 +17,20 @@
 package uk.gov.hmrc.platformstatusfrontend.services
 
 import com.google.inject.Inject
-import javax.inject.Singleton
 import org.mongodb.scala._
 import org.mongodb.scala.model.Filters._
 import org.mongodb.scala.model.ReplaceOptions
 import play.api.Logger
 import play.api.libs.concurrent.Futures
 import play.api.libs.concurrent.Futures._
-import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.platformstatusfrontend.connectors.{BackendConnector, InternetConnector}
-
-import scala.concurrent.duration._
-import PlatformStatus._
 import play.api.libs.ws.WSResponse
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.platformstatusfrontend.config.AppConfig
+import uk.gov.hmrc.platformstatusfrontend.connectors.{BackendConnector, InternetConnector}
+import uk.gov.hmrc.platformstatusfrontend.services.PlatformStatus._
 
+import javax.inject.Singleton
+import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
@@ -89,7 +88,7 @@ class StatusChecker @Inject()(
     for {
       wsResult <- internetConnector
                     .callTheWeb(webTestEndpoint, appConfig.proxyRequired)
-                    .withTimeout(2.seconds)
+                    .withTimeout(FiniteDuration(appConfig.proxyTimeout.toSeconds, SECONDS))
                     .recoverWith {
                       case ex: Exception =>
                         logger.warn("Unable to call out via squid proxy")

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -74,6 +74,7 @@ proxy.password = set_me
 proxy.required = false
 proxy.host = outbound-proxy-vip
 proxy.port = 3128
+proxy.timeout = 2s
 proxy.protocol = https
 startup-delay = 0
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -49,16 +49,6 @@ microservice {
   }
 }
 
-auditing {
-  enabled = false
-  consumer {
-    baseUri {
-      host = localhost
-      port = 8100
-    }
-  }
-}
-
 google-analytics {
   token = N/A
   host = auto

--- a/test/uk/gov/hmrc/platformstatusfrontend/controllers/StatusControllerSpec.scala
+++ b/test/uk/gov/hmrc/platformstatusfrontend/controllers/StatusControllerSpec.scala
@@ -17,19 +17,18 @@
 package uk.gov.hmrc.platformstatusfrontend.controllers
 
 import org.mockito.scalatest.MockitoSugar
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.http.Status
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import play.api.{Configuration, Environment, _}
+import play.api._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.platformstatusfrontend.config.AppConfig
 import uk.gov.hmrc.platformstatusfrontend.services.{PlatformStatus, StatusChecker}
 import uk.gov.hmrc.platformstatusfrontend.views.html.{Status => StatusView}
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -44,15 +43,8 @@ class StatusControllerSpec
   private val fakeRequest = FakeRequest("GET", "/")
   private val env           = Environment.simple()
   private val configuration: Configuration = Configuration.load(env)
-  private val serviceConfig = new ServicesConfig(configuration)
-  private val appConfig     = new AppConfig(configuration, serviceConfig)
+  private val appConfig     = new AppConfig(configuration)
 
-  override def fakeApplication(): Application =
-    new GuiceApplicationBuilder()
-      .configure(
-        "metrics.jvm" -> false
-      )
-      .build()
 
   private trait Setup {
     implicit val hc: HeaderCarrier = HeaderCarrier()

--- a/test/uk/gov/hmrc/platformstatusfrontend/services/StatusCheckerSpec.scala
+++ b/test/uk/gov/hmrc/platformstatusfrontend/services/StatusCheckerSpec.scala
@@ -89,6 +89,7 @@ class StatusCheckerSpec
     "be happy when a response is received" in new Setup() {
       val fakeResponse = mock[WSResponse]
       when(appConfig.proxyRequired).thenReturn(false)
+      when(appConfig.proxyTimeout).thenReturn(Duration(2, SECONDS))
       when(fakeResponse.status).thenReturn(200)
       when(internetConnector.callTheWeb(statusChecker.webTestEndpoint, false)).thenReturn(Future.successful(fakeResponse))
       whenReady(statusChecker.iteration4Status(), timeout(testTimeoutDuration)) {
@@ -98,6 +99,7 @@ class StatusCheckerSpec
 
     "handle things when an error response is received" in new Setup() {
       when(appConfig.proxyRequired).thenReturn(false)
+      when(appConfig.proxyTimeout).thenReturn(Duration(2, SECONDS))
       when(internetConnector.callTheWeb(statusChecker.webTestEndpoint, false)).thenReturn(Future.failed(new Exception("Borked")))
       whenReady(statusChecker.iteration4Status(), timeout(testTimeoutDuration)) {
         result => result shouldBe baseIteration4Status.copy(isWorking = false, reason = Some("Borked"))


### PR DESCRIPTION
External test seems to be slow and the proxy is timing out, want to make this a configurable timeout with a default maintained at 2s. 